### PR TITLE
Add support for Visual Studio 2013 to IL extension

### DIFF
--- a/IL Support/source.extension.vsixmanifest
+++ b/IL Support/source.extension.vsixmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
   <Identifier Id="ILSupport">
     <Name>IL Support</Name>
@@ -17,6 +17,12 @@
         <Edition>IntegratedShell</Edition>
       </VisualStudio>
       <VisualStudio Version="11.0">
+        <Edition>Ultimate</Edition>
+        <Edition>Premium</Edition>
+        <Edition>Pro</Edition>
+        <Edition>IntegratedShell</Edition>
+      </VisualStudio>
+      <VisualStudio Version="12.0">
         <Edition>Ultimate</Edition>
         <Edition>Premium</Edition>
         <Edition>Pro</Edition>


### PR DESCRIPTION
Seems like the only thing that is needed to gain syntax highlighting. I didn't try the project templates.
